### PR TITLE
Mac OSX specific fixes to make compilation work

### DIFF
--- a/src/Client/Editor/SelectionPanel.cpp
+++ b/src/Client/Editor/SelectionPanel.cpp
@@ -9,6 +9,7 @@
 #include <Shared/Utils/Utilities.hpp>
 #include <algorithm>
 #include <memory>
+#include <cmath>
 
 namespace gui2
 {

--- a/src/Shared/Utils/OSDetect.hpp
+++ b/src/Shared/Utils/OSDetect.hpp
@@ -5,7 +5,7 @@
 		#define WOS_WINDOWS
 	#elif defined __linux__ || defined __linux || defined linux
 		#define WOS_LINUX
-	#elif defined __APPLE__ && TARGET_OS_MAC
+	#elif defined __APPLE__ || defined TARGET_OS_MAC
 		#define WOS_OSX
 	#else
 		#error Unsupported operating system.


### PR DESCRIPTION
I finally took the time to compile this on my machine, as far as I can tell it works great but I needed to make a few changes for the compilation to work. I don't think those changes affect other platforms so here is a PR with them.

First error I had is about an ambiguous abs call:

```
/Users/alexis/Documents/dev/necrodancer/NecroEdit/src/Client/Editor/SelectionPanel.cpp:146:7: error: call to 'abs' is ambiguous
                if (std::abs(scrollVelocity) > 0.0001f)
                    ^~~~~~~~
/usr/include/stdlib.h:129:6: note: candidate function
int      abs(int) __pure2;
         ^
/Library/Developer/CommandLineTools/usr/bin/../include/c++/v1/cstdlib:159:44: note: candidate function
inline _LIBCPP_INLINE_VISIBILITY long      abs(     long __x) _NOEXCEPT {return  labs(__x);}
                                           ^
/Library/Developer/CommandLineTools/usr/bin/../include/c++/v1/cstdlib:161:44: note: candidate function
inline _LIBCPP_INLINE_VISIBILITY long long abs(long long __x) _NOEXCEPT {return llabs(__x);}
```

It looks like there are several abs functions to choose from (probably from XCode tools). Including cmath fixes the issue.

The second problem was the OSX detection for Clipboard.cpp:

```
In file included from /Users/alexis/Documents/dev/necrodancer/NecroEdit/src/Shared/Utils/Clipboard.cpp:2:
/Users/alexis/Documents/dev/necrodancer/NecroEdit/src/Shared/Utils/OSDetect.hpp:11:4: error: Unsupported operating system.
                #error Unsupported operating system.
                 ^
1 error generated.
```

I managed to compile with these changes and everything seem to work correctly so far (I will report bugs if I found them when I try to play more with it).
