### PR TITLE
Add OSX default game path 

### DIFF
--- a/src/Client/System/GameDirectoryGuesser.cpp
+++ b/src/Client/System/GameDirectoryGuesser.cpp
@@ -4,7 +4,7 @@
 #ifdef WOS_WINDOWS
 #	include <windows.h>
 #	include <shlobj.h>
-#elif defined WOS_LINUX
+#elif defined WOS_LINUX || defined WOS_OSX
 #	include <pwd.h>
 #	include <unistd.h>
 #	include <cstdlib>
@@ -53,9 +53,28 @@ std::vector<std::string> GameDirectoryGuesser::getDirectoryList()
 		directories.push_back(homeDirectory + "/.local/share/Steam/SteamApps/common/Crypt of the NecroDancer");
 	}
 
+#elif defined WOS_OSX
+
+	// Get user's home directory, if set through $HOME.
+	const char * homeDirectoryPtr = std::getenv("HOME");
+
+	if (homeDirectoryPtr == nullptr)
+	{
+		// Get user's home directory, if not set through $HOME.
+		homeDirectoryPtr = getpwuid(getuid())->pw_dir;
+	}
+
+	if (homeDirectoryPtr != nullptr)
+	{
+		std::string homeDirectory(homeDirectoryPtr);
+
+		directories.push_back(homeDirectory + "/Library/Application Support/Steam/steamapps/common/Crypt of the NecroDancer/NecroDancer.app/Contents/Resources");
+		// Default GOG install
+		directories.push_back("/Applications/Crypt of the Necrodancer.app/Contents/Resources/game/NecroDancer.app/Contents/Resources");
+	}
+
 #endif
 
-	// TODO: Detect game path for Mac OS X.
 
 	return directories;
 }

--- a/src/Client/System/NEWindow.cpp
+++ b/src/Client/System/NEWindow.cpp
@@ -17,6 +17,7 @@
 #include <Shared/Utils/MakeUnique.hpp>
 #include <Shared/Utils/MessageBox.hpp>
 #include <Shared/Utils/NamedFactory.hpp>
+#include <Shared/Utils/OSDetect.hpp>
 #include <Shared/Utils/StrNumCon.hpp>
 #include <Shared/Utils/Utilities.hpp>
 #include <algorithm>
@@ -227,7 +228,12 @@ void NEWindow::initToolbarButtons(std::string configSection, std::vector<Toolbar
 
 void NEWindow::initFileDialogs()
 {
-	std::string dungeonsFolder = gameDirectory + "/dungeons/";
+	#ifdef WOS_OSX
+		// On OSX, ressources and dungeons aren't in the same folder, use relative path to get to the dungeons
+		std::string dungeonsFolder = gameDirectory + "/../../../dungeons/";
+	#else
+		std::string dungeonsFolder = gameDirectory + "/dungeons/";
+	#endif
 
 	// Create dungeons folder if it does not exist yet
 	createDirectoryStructure(dungeonsFolder);


### PR DESCRIPTION
- Adding the default game path for OSX (also added GOG version path, for the 0.1 people who might need it).
- Ressources and dungeons aren't in the same folder for OSX, so fixing that (same for both steam and GOG).
